### PR TITLE
update gem dependencies for ruby 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,11 +22,12 @@ gem 'httparty', '0.7.8'
 gem 'daemons-rails'
 gem 'hallon'
 gem 'hallon-openal'
+gem 'spotify'
 gem 'private_pub'
 gem 'dnssd'
 
 group :development, :test do
-  gem 'debugger'
+  gem 'byebug'
   gem 'rspec-rails'
   gem 'guard'
   gem 'guard-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,10 @@ GEM
     bootstrap-sass (2.3.0.0)
       sass (~> 3.2)
     builder (3.0.4)
+    byebug (3.5.1)
+      columnize (~> 0.8)
+      debugger-linecache (~> 1.2)
+      slop (~> 3.6)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
       railties (~> 3.2.0)
@@ -40,7 +44,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.3.3)
-    columnize (0.3.6)
+    columnize (0.9.0)
     cookiejar (0.3.0)
     crack (0.1.8)
     daemons (1.1.9)
@@ -48,13 +52,7 @@ GEM
       daemons
       multi_json (~> 1.0)
       rails (~> 3.0)
-    debugger (1.3.1)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.1.1)
-      debugger-ruby_core_source (~> 1.1.8)
-    debugger-linecache (1.1.2)
-      debugger-ruby_core_source (>= 1.1.1)
-    debugger-ruby_core_source (1.1.8)
+    debugger-linecache (1.2.0)
     diff-lcs (1.1.3)
     dnssd (2.0)
     em-http-request (1.0.3)
@@ -166,6 +164,7 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.5.3)
     simplecov-html (0.5.3)
+    slop (3.6.0)
     spotify (12.3.0)
       ffi (~> 1.0, >= 1.0.11)
       libspotify (~> 12.1.51)
@@ -195,9 +194,9 @@ PLATFORMS
 
 DEPENDENCIES
   bootstrap-sass
+  byebug
   coffee-rails (~> 3.2.1)
   daemons-rails
-  debugger
   dnssd
   font-awesome-rails
   foreman
@@ -214,6 +213,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 3.2.3)
   simplecov
+  spotify
   thin
   uglifier (>= 1.0.3)
   underscore-rails


### PR DESCRIPTION
there is no debugger build for ruby 2.x, switched to byebug
